### PR TITLE
Fix garbled Dark Merchant event description

### DIFF
--- a/deckdeep/events.py
+++ b/deckdeep/events.py
@@ -341,7 +341,7 @@ class DarkMerchant(Event):
         cursed_dagger = get_relic_by_name("Cursed Dagger")
         super().__init__(
             "Dark Merchant",
-            f"A shadowy figure appears offers you a mysterious dagger. A Do you can accept the '{cursed_dagger.name}' in exchange for 15 max HP?",
+            f"A shadowy figure appears and offers you a mysterious dagger. Do you accept the '{cursed_dagger.name}' in exchange for 15 max HP?",
             [
                 ("Accept dagger", "accept_dagger"),
                 ("Decline and leave", "leave"),


### PR DESCRIPTION
Fixes the broken grammar in the Dark Merchant event description (`appears offers`, `A Do you can accept`), rewriting it to read naturally. Text-only copy edit: keeps the `cursed_dagger.name` f-string interpolation and the `15 max HP` detail; no game logic changed.

`python -m pytest -q` green (14 passed).

Closes #4