### PR TITLE
Add regression test for corrected Dark Merchant event text

### DIFF
--- a/tests/test_dark_merchant.py
+++ b/tests/test_dark_merchant.py
@@ -1,0 +1,20 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from deckdeep.events import DarkMerchant  # noqa: E402
+
+
+def test_dark_merchant_description_is_well_formed():
+    """Regression: the Dark Merchant event description must use the corrected,
+    grammatical phrasing and never the old garbled text."""
+    description = DarkMerchant().description
+
+    # Corrected phrasing must be present.
+    assert "appears and offers you" in description
+    assert "Do you accept" in description
+
+    # Old garbled fragments must never reappear.
+    assert "appears offers" not in description
+    assert "A Do you can accept" not in description


### PR DESCRIPTION
Adds a regression test guarding the corrected Dark Merchant event description (fixed in #7).

- Asserts the well-formed text is present (`appears and offers you`, `Do you accept`)
- Asserts the old garbled fragments never reappear (`appears offers`, `A Do you can accept`)
- Mutation-verified: fails on the old garbled text, passes on current
- Suite: 15 passed (was 14)

Closes #4