### PR TITLE
Add text_utils (truncate_name, wrap_name) + Relic.display_name

### DIFF
--- a/deckdeep/relic.py
+++ b/deckdeep/relic.py
@@ -4,6 +4,8 @@ from typing import Dict
 from copy import deepcopy
 import uuid
 
+from deckdeep.text_utils import truncate_name
+
 
 class TriggerWhen(Enum):
     START_OF_TURN = 0
@@ -46,6 +48,11 @@ class Relic:
 
     def reset_application_status(self):
         self.has_been_applied = False
+
+    @property
+    def display_name(self) -> str:
+        """A UI-friendly name capped at 18 characters and ending in an ellipsis."""
+        return truncate_name(self.name, 18)
 
     @classmethod
     def from_dict(cls, data: Dict) -> "Relic":

--- a/deckdeep/text_utils.py
+++ b/deckdeep/text_utils.py
@@ -1,0 +1,71 @@
+"""Pure-stdlib helpers for fitting long display names into UI elements."""
+
+
+_ELLIPSIS = "\u2026"
+
+
+def truncate_name(name: str, max_len: int) -> str:
+    """Return ``name`` shortened to at most ``max_len`` characters.
+
+    - Names already at or below ``max_len`` are returned unchanged.
+    - Longer names are trimmed to ``max_len - 1`` characters, stripped of
+      trailing whitespace, and terminated with a single-character ellipsis.
+    - ``max_len <= 1`` always yields just the ellipsis.
+    """
+    if not isinstance(name, str):
+        raise TypeError("name must be a str")
+    if not isinstance(max_len, int) or isinstance(max_len, bool):
+        raise TypeError("max_len must be an int")
+    if max_len <= 1:
+        return _ELLIPSIS
+    if len(name) <= max_len:
+        return name
+    return name[: max_len - 1].rstrip() + _ELLIPSIS
+
+
+def wrap_name(name: str, max_width: int) -> list:
+    """Wrap ``name`` into lines that each fit within ``max_width`` characters.
+
+    Behaviour:
+    - Empty strings and whitespace-only input return ``[]``.
+    - Runs of whitespace are collapsed to single spaces.
+    - Words are packed greedily onto a line while they still fit.
+    - A single word longer than ``max_width`` is hard-split into chunks of
+      ``max_width`` characters.
+    """
+    if not isinstance(name, str):
+        raise TypeError("name must be a str")
+    if not isinstance(max_width, int) or isinstance(max_width, bool):
+        raise TypeError("max_width must be an int")
+    if max_width <= 0:
+        raise ValueError("max_width must be positive")
+
+    collapsed = " ".join(name.split())
+    if not collapsed:
+        return []
+
+    words = collapsed.split(" ")
+    lines: list = []
+    current = ""
+    for word in words:
+        if len(word) <= max_width:
+            candidate = word if not current else current + " " + word
+            if len(candidate) <= max_width:
+                current = candidate
+            else:
+                if current:
+                    lines.append(current)
+                current = word
+        else:
+            if current:
+                lines.append(current)
+                current = ""
+            for start in range(0, len(word), max_width):
+                chunk = word[start : start + max_width]
+                if len(chunk) == max_width:
+                    lines.append(chunk)
+                else:
+                    current = chunk
+    if current:
+        lines.append(current)
+    return lines

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,112 @@
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from deckdeep.relic import Relic  # noqa: E402
+from deckdeep.text_utils import truncate_name, wrap_name  # noqa: E402
+
+
+_ELLIPSIS = "\u2026"
+
+
+def test_truncate_name_short_unchanged():
+    assert truncate_name("Hair of the Dog", 18) == "Hair of the Dog"
+    assert truncate_name("Cursed Coin", 12) == "Cursed Coin"
+
+
+def test_truncate_name_long_gets_ellipsis_within_max_len():
+    out = truncate_name("Equivalent Exchange", 18)
+    assert out == "Equivalent Exchan" + _ELLIPSIS
+    assert len(out) == 18
+    assert out.endswith(_ELLIPSIS)
+
+
+def test_truncate_name_strips_trailing_whitespace_before_ellipsis():
+    name = "abc   " + "defghijklmnopqrstuvwxyz"
+    out = truncate_name(name, 12)
+    assert out.endswith(_ELLIPSIS)
+    assert len(out) <= 12
+    assert not out[:-1].endswith(" ")
+
+
+def test_truncate_name_max_len_one_returns_ellipsis():
+    assert truncate_name("anything", 1) == _ELLIPSIS
+
+
+def test_truncate_name_max_len_zero_returns_ellipsis():
+    assert truncate_name("anything", 0) == _ELLIPSIS
+    assert truncate_name("anything", -5) == _ELLIPSIS
+
+
+def test_truncate_name_exact_length_unchanged():
+    name = "abcdefghij"  # 10 chars
+    assert truncate_name(name, 10) == name
+
+
+def test_relic_display_name_caps_long_name_with_ellipsis():
+    relic = Relic(
+        "Equivalent Exchange",
+        {
+            "description": "Test relic.",
+            "effect": lambda p, g: None,
+            "trigger_when": 0,
+        },
+    )
+    assert relic.display_name == "Equivalent Exchan" + _ELLIPSIS
+    assert len(relic.display_name) == 18
+    assert relic.display_name.endswith(_ELLIPSIS)
+
+
+def test_relic_display_name_short_name_unchanged():
+    relic = Relic(
+        "Cursed Coin",
+        {
+            "description": "Test relic.",
+            "effect": lambda p, g: None,
+            "trigger_when": 0,
+        },
+    )
+    assert relic.display_name == "Cursed Coin"
+
+
+def test_wrap_name_empty_returns_empty_list():
+    assert wrap_name("", 10) == []
+    assert wrap_name("   ", 10) == []
+    assert wrap_name("\t\n  ", 10) == []
+
+
+def test_wrap_name_collapses_whitespace():
+    assert wrap_name("hello   world", 20) == ["hello world"]
+
+
+def test_wrap_name_greedy_word_wrap():
+    assert wrap_name("a very long string indeed", 10) == [
+        "a very",
+        "long",
+        "string",
+        "indeed",
+    ]
+
+
+def test_wrap_name_hard_splits_overwidth_words():
+    result = wrap_name("supercalifragilistic", 5)
+    assert result == ["super", "calif", "ragil", "istic"]
+    assert all(len(line) <= 5 for line in result)
+
+
+def test_wrap_name_mix_short_and_overwidth_words():
+    result = wrap_name("hi supercalifragilistic bye", 5)
+    assert result == ["hi", "super", "calif", "ragil", "istic", "bye"]
+    assert all(len(line) <= 5 for line in result)
+
+
+def test_wrap_name_fits_exactly():
+    assert wrap_name("hello world", 11) == ["hello world"]
+
+
+def test_wrap_name_each_line_respects_max_width():
+    text = "the quick brown fox jumps over the lazy dog"
+    for width in (5, 8, 12, 20):
+        for line in wrap_name(text, width):
+            assert len(line) <= width


### PR DESCRIPTION
Adds `deckdeep/text_utils.py` with pure-stdlib `truncate_name` and `wrap_name` helpers, plus a `Relic.display_name` property capping long relic names at 18 chars with an ellipsis.

- truncate_name: short unchanged; long -> name[:max_len-1].rstrip()+ellipsis (len<=max_len); max_len<=1 -> ellipsis
- wrap_name: greedy word-wrap, hard-split of over-width words, collapsed whitespace, empty/whitespace -> []
- 15 new tests in tests/test_text_utils.py (30 total, all green)
- Pure standard library, no pygame import, no game logic changed

Verifier: `python -m pytest -q` -> 30 passed.